### PR TITLE
Fix include paths to libcvalgo histogram source files

### DIFF
--- a/src/libcvalgo/histogram.cc
+++ b/src/libcvalgo/histogram.cc
@@ -2,7 +2,7 @@
    Copyright (C) 2003 Dirk Farin.    Unauthorized redistribution is prohibited.
  ********************************************************************************/
 
-#include "libcvalgo/features/histogram.hh"
+#include "libcvalgo/histogram.hh"
 
 namespace cvalgo {
 

--- a/src/libcvalgo/histogram.hh
+++ b/src/libcvalgo/histogram.hh
@@ -1,5 +1,5 @@
 /********************************************************************************
-  $Header: /home/farin/cvs/libcvalgo/libcvalgo/features/histogram.hh,v 1.4 2004/09/29 08:54:41 farin Exp $
+  $Header: /home/farin/cvs/libcvalgo/libcvalgo/histogram.hh,v 1.4 2004/09/29 08:54:41 farin Exp $
 
     Simple histogram data structure.
  ********************************************************************************

--- a/src/libcvalgo/histogram_diff.cc
+++ b/src/libcvalgo/histogram_diff.cc
@@ -2,7 +2,7 @@
    Copyright (C) 2003 Dirk Farin.    Unauthorized redistribution is prohibited.
  ********************************************************************************/
 
-#include "libcvalgo/features/histogram_diff.hh"
+#include "libcvalgo/histogram_diff.hh"
 
 namespace cvalgo {
 

--- a/src/libcvalgo/histogram_diff.hh
+++ b/src/libcvalgo/histogram_diff.hh
@@ -1,5 +1,5 @@
 /********************************************************************************
-  $Header: /home/farin/cvs/libcvalgo/libcvalgo/features/histogram_diff.hh,v 1.3 2004/09/29 08:54:41 farin Exp $
+  $Header: /home/farin/cvs/libcvalgo/libcvalgo/histogram_diff.hh,v 1.3 2004/09/29 08:54:41 farin Exp $
 
     Simple histogram difference measures.
  ********************************************************************************
@@ -9,7 +9,7 @@
 #ifndef LIBCVALGO_FEATURES_HISTOGRAM_DIFF_HH
 #define LIBCVALGO_FEATURES_HISTOGRAM_DIFF_HH
 
-#include "libcvalgo/features/histogram.hh"
+#include "libcvalgo/histogram.hh"
 
 namespace cvalgo {
   using namespace videogfx;


### PR DESCRIPTION
`make` compilation fails, because it can't find those includes in their path. I've changed paths in those includes (moving those files to 'features' dir would probably do the same) and it compiled correctly.